### PR TITLE
 test_embed.py: memory optimization

### DIFF
--- a/test_embed.py
+++ b/test_embed.py
@@ -3,6 +3,7 @@ import sys
 import os
 import scipy
 import sklearn
+import csv
 print "aaaa scipy", scipy.__version__
 print "bbbb numpy", np.__version__
 print "ccccc sklearn", sklearn.__version__
@@ -16,7 +17,19 @@ subject = sys.argv[1]
 out_path = '/ptmp/sbayrak/embed_out'
 # set as local output directory (HYDRA)
 
-L = np.loadtxt(subject)
+# a replacement for numpy.loadtxt() which used 5 times more memory than needed
+def load_matrix(file):
+    n = -1
+    with open(file, 'r') as f:
+        reader = csv.reader(f,'excel-tab')
+        for i, row in enumerate(reader):
+            if n < 0:
+                n = len(row)
+                b = np.zeros((n,n))
+            b[i,:] = np.array(row)
+    return b
+
+L = load_matrix(subject)
 
 def save_output(subject, embed_matrix):
     out_dir = os.path.join(out_path)

--- a/test_embed.py
+++ b/test_embed.py
@@ -43,7 +43,7 @@ def save_output(subject, embed_matrix):
     return out_file
 
 embedding, result = embed.compute_diffusion_map(L, alpha=0, n_components=5, 
-diffusion_time=0)
+diffusion_time=0, skip_checks=True, overwrite=True)
 
 save_output(subject, embedding)
 


### PR DESCRIPTION
These both patches should make you able to run 60k matrices using less than 64 GB memory.
